### PR TITLE
PS-162: Add canopy ESLint plugin sub-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ export default [
   },
 ];
 ```
+
+## Plugin rules (opt-in)
+
+This package also ships a `canopy` ESLint plugin via the `eslint-config-canopy/plugin` sub-export. It is not enabled by default — register it and pick the rules you want:
+
+```javascript
+import canopyConfig from "eslint-config-canopy";
+import canopyPlugin from "eslint-config-canopy/plugin";
+
+export default [
+  ...canopyConfig,
+  {
+    plugins: { canopy: canopyPlugin },
+    rules: {
+      "canopy/no-cp-class-in-tw": "error",
+    },
+  },
+];
+```
+
+### Available rules
+
+| Rule | Description |
+| --- | --- |
+| `canopy/no-cp-class-in-tw` | Disallows Canopy `cp-*` class tokens inside `tw(...)` calls. Tailwind's `tw()` helper applies a per-app prefix to every token, so `tw("cp-body")` produces a broken class like `fo-cp-body`. Use `always("cp-body", tw(...))` or place the `cp-*` class outside `tw()`. |

--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
   "name": "eslint-config-canopy",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "A standard eslint configuration for Canopy frontend developers",
   "main": "eslint.config.js",
   "type": "module",
+  "exports": {
+    ".": "./eslint.config.js",
+    "./plugin": "./plugin/index.js"
+  },
+  "files": [
+    "eslint.config.js",
+    "plugin"
+  ],
+  "scripts": {
+    "lint": "eslint .",
+    "test": "node --test plugin/rules/*.test.js"
+  },
   "repository": "git@canopy.githost.io:front-end/canopy-eslint.git",
   "license": "Apache-2.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./eslint.config.js",
+    "./eslint.config.js": "./eslint.config.js",
     "./plugin": "./plugin/index.js"
   },
   "files": [
@@ -14,7 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "node --test plugin/rules/*.test.js"
+    "test": "node --test"
   },
   "repository": "git@canopy.githost.io:front-end/canopy-eslint.git",
   "license": "Apache-2.0",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,0 +1,12 @@
+import noCpClassInTw from './rules/no-cp-class-in-tw.js';
+
+const plugin = {
+  meta: {
+    name: 'canopy',
+  },
+  rules: {
+    'no-cp-class-in-tw': noCpClassInTw,
+  },
+};
+
+export default plugin;

--- a/plugin/rules/no-cp-class-in-tw.js
+++ b/plugin/rules/no-cp-class-in-tw.js
@@ -1,0 +1,77 @@
+// Match cp-* at string start or after any non-word-non-hyphen character.
+// Excluding `-` preserves CSS custom properties like `--cp-color-*` inside
+// arbitrary-value brackets (e.g. `bg-[var(--cp-color-app-border)]`).
+const CP_TOKEN_RE = /(?:^|[^\w-])(cp-[A-Za-z0-9_-]+)/g;
+
+function findCpTokens(str) {
+  if (typeof str !== 'string') return [];
+  const tokens = [];
+  for (const m of str.matchAll(CP_TOKEN_RE)) {
+    tokens.push(m[1]);
+  }
+  return tokens;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Canopy `cp-*` classes inside tw() calls — tw() prefixes every token, so `cp-body` becomes `fo-cp-body` and breaks. Use always(`cp-body`, tw(`...`)) instead.',
+    },
+    schema: [],
+    messages: {
+      cpInTw:
+        '`{{token}}` is a Canopy class and must not be passed through tw() — it will be prefixed and break. Use `always("{{token}}", tw(...))` or a template literal.',
+    },
+  },
+
+  create(context) {
+    function reportCp(node, token) {
+      context.report({ node, messageId: 'cpInTw', data: { token } });
+    }
+
+    function walkInsideTw(node) {
+      if (!node) return;
+
+      switch (node.type) {
+        case 'Literal': {
+          for (const token of findCpTokens(node.value)) reportCp(node, token);
+          return;
+        }
+        case 'TemplateLiteral': {
+          for (const q of node.quasis) {
+            for (const token of findCpTokens(q.value.cooked ?? q.value.raw ?? '')) {
+              reportCp(q, token);
+            }
+          }
+          node.expressions.forEach(walkInsideTw);
+          return;
+        }
+        case 'CallExpression':
+          node.arguments.forEach(walkInsideTw);
+          return;
+        case 'ConditionalExpression':
+          walkInsideTw(node.consequent);
+          walkInsideTw(node.alternate);
+          return;
+        case 'LogicalExpression':
+          walkInsideTw(node.left);
+          walkInsideTw(node.right);
+          return;
+        case 'ArrayExpression':
+          node.elements.forEach(walkInsideTw);
+          return;
+        default:
+          return;
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'tw') return;
+        node.arguments.forEach(walkInsideTw);
+      },
+    };
+  },
+};

--- a/plugin/rules/no-cp-class-in-tw.js
+++ b/plugin/rules/no-cp-class-in-tw.js
@@ -22,7 +22,7 @@ export default {
     schema: [],
     messages: {
       cpInTw:
-        '`{{token}}` is a Canopy class and must not be passed through tw() — it will be prefixed and break. Use `always("{{token}}", tw(...))` or a template literal.',
+        '`{{token}}` is a Canopy class and must not be passed through tw() — it will be prefixed and break. Keep `cp-*` outside tw(), e.g. `always("{{token}}", tw(...))` or `` `{{token}} ${tw(...)}` ``.',
     },
   },
 
@@ -61,6 +61,12 @@ export default {
           return;
         case 'ArrayExpression':
           node.elements.forEach(walkInsideTw);
+          return;
+        case 'BinaryExpression':
+          if (node.operator === '+') {
+            walkInsideTw(node.left);
+            walkInsideTw(node.right);
+          }
           return;
         default:
           return;

--- a/plugin/rules/no-cp-class-in-tw.test.js
+++ b/plugin/rules/no-cp-class-in-tw.test.js
@@ -1,0 +1,83 @@
+import { RuleTester } from 'eslint';
+import rule from './no-cp-class-in-tw.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-cp-class-in-tw', rule, {
+  valid: [
+    { code: `tw("flex flex-col gap-4")` },
+    { code: `always("cp-body", tw("flex"))` },
+    { code: `always("cp-body flex")` },
+    // CSS-var bracket notation should NOT trip — `cp-` is not preceded by start/space
+    { code: `tw("bg-[var(--cp-color-app-border)]")` },
+    { code: `tw("text-[var(--cp-color-app-secondary-text)] italic")` },
+    // Substring-only matches should be ignored
+    { code: `tw("font-cpx-regular")` },
+    // Template literal with no cp- token
+    { code: 'tw(`flex ${variant} gap-4`)' },
+    // Different function name
+    { code: `twx("cp-body flex")` },
+    // cp-* inside maybe() outside tw() is fine
+    { code: `maybe(x, "cp-body")` },
+  ],
+  invalid: [
+    {
+      code: `tw("cp-body flex")`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    {
+      code: `tw("flex cp-body")`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    {
+      code: `tw("cp-body-sm cp-wt-semibold")`,
+      errors: [
+        { messageId: 'cpInTw', data: { token: 'cp-body-sm' } },
+        { messageId: 'cpInTw', data: { token: 'cp-wt-semibold' } },
+      ],
+    },
+    {
+      code: `tw("w-full italic cp-caption", maybe(x, "flex"))`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-caption' } }],
+    },
+    // nested through maybe() inside tw()
+    {
+      code: `tw("flex", maybe(x, "cp-body"))`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    // nested through ternary inside tw()
+    {
+      code: `tw("flex", cond ? "cp-body" : "cp-caption")`,
+      errors: [
+        { messageId: 'cpInTw', data: { token: 'cp-body' } },
+        { messageId: 'cpInTw', data: { token: 'cp-caption' } },
+      ],
+    },
+    // template literal
+    {
+      code: 'tw(`cp-body ${x}`)',
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    // Tailwind variant-prefixed tokens
+    {
+      code: `tw("hover:cp-body")`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    {
+      code: `tw("md:cp-body flex")`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    {
+      code: `tw("!cp-caption")`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-caption' } }],
+    },
+  ],
+});

--- a/test/rules/no-cp-class-in-tw.test.js
+++ b/test/rules/no-cp-class-in-tw.test.js
@@ -1,5 +1,5 @@
 import { RuleTester } from 'eslint';
-import rule from './no-cp-class-in-tw.js';
+import rule from '../../plugin/rules/no-cp-class-in-tw.js';
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -16,7 +16,7 @@ ruleTester.run('no-cp-class-in-tw', rule, {
     { code: `tw("flex flex-col gap-4")` },
     { code: `always("cp-body", tw("flex"))` },
     { code: `always("cp-body flex")` },
-    // CSS-var bracket notation should NOT trip — `cp-` is not preceded by start/space
+    // CSS-var bracket notation should NOT trip — the char before `cp-` is `-`, which the regex excludes
     { code: `tw("bg-[var(--cp-color-app-border)]")` },
     { code: `tw("text-[var(--cp-color-app-secondary-text)] italic")` },
     // Substring-only matches should be ignored
@@ -64,6 +64,15 @@ ruleTester.run('no-cp-class-in-tw', rule, {
     // template literal
     {
       code: 'tw(`cp-body ${x}`)',
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    // String concatenation inside tw()
+    {
+      code: `tw("cp-body " + extra)`,
+      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+    },
+    {
+      code: `tw("flex " + "cp-body")`,
       errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
     },
     // Tailwind variant-prefixed tokens


### PR DESCRIPTION
## Jira Ticket
[PS-162]

## Purpose
Canopy frontend repos with tailwind use the Tailwind `tw()` helper, which prefixes every class token with a per-app prefix. When a Canopy `cp-*` class slips into a `tw()` call (e.g. `tw("cp-body flex")`) the class gets re-prefixed to something like `fo-cp-body` and silently breaks styling at runtime. Add an ESLint rule catching this into the shared `eslint-config-canopy` package so every consuming repo gets the same enforcement from one source without duplicating the rule across codebases.

## Summary
- Add `plugin/` directory and ship it as the `eslint-config-canopy/plugin` sub-export via the `exports` map in `package.json`.
- Add the initial rule `canopy/no-cp-class-in-tw` (ported from forms-ui, converted to ESM), plus unit tests using ESLint's `RuleTester`.
- Bump version `5.0.1` → `5.1.0` (new feature, backwards-compatible — the plugin is opt-in, not enabled by default).
- Add `lint` script that dogfoods the package's own exported config, and `test` script via `node --test`.
- Update `README.md` with consumer-side usage for the new plugin sub-export.

## Test plan
- [ ] `yarn install` succeeds in a consuming repo after bumping to `5.1.0`.
- [ ] `import canopyPlugin from "eslint-config-canopy/plugin"` resolves.
- [ ] Registering `{ plugins: { canopy: canopyPlugin }, rules: { "canopy/no-cp-class-in-tw": "error" } }` in a consumer's `eslint.config.js` lints as expected: `tw("cp-body flex")` errors, `always("cp-body", tw("flex"))` passes, `tw("hover:cp-body")` errors, `tw("bg-[var(--cp-color-app-border)]")` passes.
- [ ] `yarn test` passes in this repo.
- [ ] `yarn lint` passes in this repo.

[PS-162]: https://canopytax.atlassian.net/browse/PS-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ