### PR TITLE
Bump version to 5.2.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import unusedImports from 'eslint-plugin-unused-imports';
 import importPlugin from 'eslint-plugin-import';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import canopyPlugin from './plugin/index.js';
 
 export default [
   jsPlugin.configs.recommended,
@@ -45,6 +46,7 @@ export default [
       'react': reactPlugin,
       'unused-imports': unusedImports,
       'import': importPlugin,
+      'canopy': canopyPlugin,
     },
     // Rules configuration
     rules: {
@@ -94,6 +96,9 @@ export default [
       'no-const-assign': 'error',
       'no-dupe-class-members': 'error',
       'no-this-before-super': 'error',
+
+      // Canopy
+      'canopy/no-cp-class-in-tw': 'warn',
 
       // TypeScript
       '@typescript-eslint/no-unused-vars': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-canopy",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A standard eslint configuration for Canopy frontend developers",
   "main": "eslint.config.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `eslint-config-canopy` from 5.1.0 to 5.2.0 to release the new canopy ESLint plugin sub-export (`eslint-config-canopy/plugin`).

## Test plan
- [ ] CI passes
- [ ] After merge, publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)