### PR TITLE
refactor: `no-cp-class-in-tw` rule with suggestions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ export default [
 
 | Rule | Description |
 | --- | --- |
-| `canopy/no-cp-class-in-tw` | Disallows Canopy `cp-*` class tokens inside `tw(...)` calls. Tailwind's `tw()` helper applies a per-app prefix to every token, so `tw("cp-body")` produces a broken class like `fo-cp-body`. Use `always("cp-body", tw(...))` or place the `cp-*` class outside `tw()`. |
+| [`canopy/no-cp-class-in-tw`](docs/rules/no-cp-class-in-tw.md) | Disallows Canopy `cp-*` class tokens inside `tw(...)` calls. Tailwind's `tw()` helper applies a per-app prefix to every token, so `tw("cp-body")` produces a broken class like `fo-cp-body`. Use `always("cp-body", tw(...))` or place the `cp-*` class outside `tw()`. Offers a suggestion fix for flat string-literal calls. |

--- a/docs/rules/no-cp-class-in-tw.md
+++ b/docs/rules/no-cp-class-in-tw.md
@@ -1,0 +1,61 @@
+# Disallow Canopy `cp-*` classes inside `tw()` (no-cp-class-in-tw)
+
+Canopy's `tw()` classname helper applies a per-app Tailwind **prefix** to every
+token it receives. Design-system classes (`cp-*`) are global and unprefixed, so
+passing one through `tw()` rewrites it — with a `fo-` prefix, `tw("cp-body")`
+emits `fo-cp-body`, a class that doesn't exist, silently dropping the styling.
+
+## Rule Details
+
+This rule reports any `cp-*` class token that appears inside a `tw()` call. It
+looks through the common ways tokens reach `tw()`: plain strings, template
+literals, ternaries, logical (`&&` / `||`) expressions, arrays, string
+concatenation (`+`), and nested helper calls. CSS custom properties referenced
+inside arbitrary values (e.g. `bg-[var(--cp-color-app-border)]`) are **not**
+reported — only standalone `cp-*` class tokens are.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint canopy/no-cp-class-in-tw: "error"*/
+
+tw("cp-body flex");
+tw("cp-wt-semibold mb-1");
+tw("flex", isActive ? "cp-body" : "cp-caption");
+tw(`cp-body ${variant}`);
+tw("flex", maybe(open, "cp-body"));
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint canopy/no-cp-class-in-tw: "error"*/
+
+always("cp-body", tw("flex"));
+always("cp-wt-semibold", tw("mb-1"));
+tw("flex flex-col gap-4");
+tw("bg-[var(--cp-color-app-border)]");
+maybe(open, "cp-body");
+```
+
+## Suggestions
+
+When every argument to the `tw()` call is a plain string literal, the rule
+offers an editor suggestion that hoists the `cp-*` tokens into `always()`:
+
+```js
+tw("cp-body p-2")        // → always("cp-body", tw("p-2"))
+tw("cp-body cp-caption") // → always("cp-body cp-caption")
+```
+
+The suggestion assumes `always` is already in scope (it ships alongside `tw` in
+`@canopytax/understory`); it does **not** add or modify imports. Dynamic calls
+(ternaries, nested calls, concatenation, templates) are reported but not
+auto-rewritten, since hoisting tokens out of them isn't a safe mechanical edit.
+
+## When Not To Use It
+
+If your app initializes the classname helpers with an **empty** prefix,
+`tw("cp-body")` does not break at runtime — the rule is then a
+stylistic/consistency guard rather than a correctness one, so you may prefer to
+keep it at `warn` (the default severity) or disable it.

--- a/plugin/rules/no-cp-class-in-tw.js
+++ b/plugin/rules/no-cp-class-in-tw.js
@@ -18,54 +18,89 @@ export default {
     docs: {
       description:
         'Disallow Canopy `cp-*` classes inside tw() calls — tw() prefixes every token, so `cp-body` becomes `fo-cp-body` and breaks. Use always(`cp-body`, tw(`...`)) instead.',
+      url: 'https://github.com/CanopyTax/eslint-config-canopy/blob/master/docs/rules/no-cp-class-in-tw.md',
     },
+    hasSuggestions: true,
     schema: [],
     messages: {
       cpInTw:
         '`{{token}}` is a Canopy class and must not be passed through tw() — it will be prefixed and break. Keep `cp-*` outside tw(), e.g. `always("{{token}}", tw(...))` or `` `{{token}} ${tw(...)}` ``.',
+      moveToAlways: 'Move cp-* classes out of tw() and into always().',
     },
   },
 
   create(context) {
-    function reportCp(node, token) {
-      context.report({ node, messageId: 'cpInTw', data: { token } });
+    function reportCp(node, token, suggest) {
+      const descriptor = { node, messageId: 'cpInTw', data: { token } };
+      if (suggest) descriptor.suggest = suggest;
+      context.report(descriptor);
     }
 
-    function walkInsideTw(node) {
+    function buildAlwaysSuggestion(twNode) {
+      const args = twNode.arguments;
+      if (args.length === 0) return null;
+      for (const arg of args) {
+        if (arg.type !== 'Literal' || typeof arg.value !== 'string') return null;
+      }
+
+      const cp = [];
+      const rest = [];
+      for (const arg of args) {
+        for (const tok of arg.value.split(/\s+/).filter(Boolean)) {
+          (tok.startsWith('cp-') ? cp : rest).push(tok);
+        }
+      }
+      if (cp.length === 0) return null;
+
+      const twName = twNode.callee.name;
+      const cpStr = cp.join(' ');
+      const replacement = rest.length
+        ? `always("${cpStr}", ${twName}("${rest.join(' ')}"))`
+        : `always("${cpStr}")`;
+
+      return [
+        {
+          messageId: 'moveToAlways',
+          fix: (fixer) => fixer.replaceText(twNode, replacement),
+        },
+      ];
+    }
+
+    function walkInsideTw(node, suggest) {
       if (!node) return;
 
       switch (node.type) {
         case 'Literal': {
-          for (const token of findCpTokens(node.value)) reportCp(node, token);
+          for (const token of findCpTokens(node.value)) reportCp(node, token, suggest);
           return;
         }
         case 'TemplateLiteral': {
           for (const q of node.quasis) {
             for (const token of findCpTokens(q.value.cooked ?? q.value.raw ?? '')) {
-              reportCp(q, token);
+              reportCp(q, token, suggest);
             }
           }
-          node.expressions.forEach(walkInsideTw);
+          node.expressions.forEach((expr) => walkInsideTw(expr, suggest));
           return;
         }
         case 'CallExpression':
-          node.arguments.forEach(walkInsideTw);
+          node.arguments.forEach((arg) => walkInsideTw(arg, suggest));
           return;
         case 'ConditionalExpression':
-          walkInsideTw(node.consequent);
-          walkInsideTw(node.alternate);
+          walkInsideTw(node.consequent, suggest);
+          walkInsideTw(node.alternate, suggest);
           return;
         case 'LogicalExpression':
-          walkInsideTw(node.left);
-          walkInsideTw(node.right);
+          walkInsideTw(node.left, suggest);
+          walkInsideTw(node.right, suggest);
           return;
         case 'ArrayExpression':
-          node.elements.forEach(walkInsideTw);
+          node.elements.forEach((el) => walkInsideTw(el, suggest));
           return;
         case 'BinaryExpression':
           if (node.operator === '+') {
-            walkInsideTw(node.left);
-            walkInsideTw(node.right);
+            walkInsideTw(node.left, suggest);
+            walkInsideTw(node.right, suggest);
           }
           return;
         default:
@@ -76,7 +111,8 @@ export default {
     return {
       CallExpression(node) {
         if (node.callee.type !== 'Identifier' || node.callee.name !== 'tw') return;
-        node.arguments.forEach(walkInsideTw);
+        const suggest = buildAlwaysSuggestion(node);
+        node.arguments.forEach((arg) => walkInsideTw(arg, suggest));
       },
     };
   },

--- a/test/rules/no-cp-class-in-tw.test.js
+++ b/test/rules/no-cp-class-in-tw.test.js
@@ -31,17 +31,85 @@ ruleTester.run('no-cp-class-in-tw', rule, {
   invalid: [
     {
       code: `tw("cp-body flex")`,
-      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+      errors: [
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-body' },
+          suggestions: [
+            { messageId: 'moveToAlways', output: `always("cp-body", tw("flex"))` },
+          ],
+        },
+      ],
     },
     {
       code: `tw("flex cp-body")`,
-      errors: [{ messageId: 'cpInTw', data: { token: 'cp-body' } }],
+      errors: [
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-body' },
+          suggestions: [
+            { messageId: 'moveToAlways', output: `always("cp-body", tw("flex"))` },
+          ],
+        },
+      ],
     },
     {
+      // all tokens are cp-* -> always("...") with no leftover tw() call
       code: `tw("cp-body-sm cp-wt-semibold")`,
       errors: [
-        { messageId: 'cpInTw', data: { token: 'cp-body-sm' } },
-        { messageId: 'cpInTw', data: { token: 'cp-wt-semibold' } },
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-body-sm' },
+          suggestions: [
+            { messageId: 'moveToAlways', output: `always("cp-body-sm cp-wt-semibold")` },
+          ],
+        },
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-wt-semibold' },
+          suggestions: [
+            { messageId: 'moveToAlways', output: `always("cp-body-sm cp-wt-semibold")` },
+          ],
+        },
+      ],
+    },
+    {
+      // mixed cp-* + tailwind -> always("cp-*", tw("..."))
+      code: `tw("cp-wt-semibold mb-1")`,
+      errors: [
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-wt-semibold' },
+          suggestions: [
+            { messageId: 'moveToAlways', output: `always("cp-wt-semibold", tw("mb-1"))` },
+          ],
+        },
+      ],
+    },
+    {
+      // multiple string-literal args are flattened across the suggestion
+      code: `tw("cp-body p-2", "cp-caption m-1")`,
+      errors: [
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-body' },
+          suggestions: [
+            {
+              messageId: 'moveToAlways',
+              output: `always("cp-body cp-caption", tw("p-2 m-1"))`,
+            },
+          ],
+        },
+        {
+          messageId: 'cpInTw',
+          data: { token: 'cp-caption' },
+          suggestions: [
+            {
+              messageId: 'moveToAlways',
+              output: `always("cp-body cp-caption", tw("p-2 m-1"))`,
+            },
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
# Summary
Adds an opt-in autofix suggestion to `canopy/no-cp-class-in-tw` and added documentation. Detection should remain the same, and this PR only aims to add a suggested fix and docs.

## What changed
- **Suggestion fix:** when every tw() argument is a plain string literal, the rule now offers a suggestion that hoists cp-* tokens into always():
mixed → always("cp-…", tw("…")); all cp-* → always("cp-…")
- Assumes always is in scope; does not add/modify imports (the rule matches helpers by bare name and can't know each app's import path). Dynamic/nested calls (ternaries, nested calls, +, templates) stay report-only.
- Added meta.hasSuggestions + meta.docs.url.
- new docs/rules/no-cp-class-in-tw.md (standard ESLint rule-doc format: overview, Rule Details, incorrect/correct examples, suggestion behavior, When Not To Use It), linked from the README rules table.
- extended the node --test RuleTester suite to assert the suggestion output (flat mixed, all-cp-*, and multi-arg cases).