### PR TITLE
feat: add new ESLint rules for ternary and conditional class patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ export default [
 | Rule | Description |
 | --- | --- |
 | [`canopy/no-cp-class-in-tw`](docs/rules/no-cp-class-in-tw.md) | Disallows Canopy `cp-*` class tokens inside `tw(...)` calls. Tailwind's `tw()` helper applies a per-app prefix to every token, so `tw("cp-body")` produces a broken class like `fo-cp-body`. Use `always("cp-body", tw(...))` or place the `cp-*` class outside `tw()`. Offers a suggestion fix for flat string-literal calls. |
+| [`canopy/no-class-ternary`](docs/rules/no-class-ternary.md) | Disallows a class-selecting ternary (both branches non-empty) in a JSX `className` attribute or a `tw(...)` / `always(...)` call. Use `toggle(cond, whenTrue, whenFalse)` instead. Auto-fixable. |
+| [`canopy/no-conditional-class`](docs/rules/no-conditional-class.md) | Disallows an empty-branch ternary (`cond ? "x" : ""`) or a `cond && "x"` short-circuit in a JSX `className` attribute or a `tw(...)` / `always(...)` call. Use `maybe(cond, "x")` instead. Auto-fixable. |

--- a/docs/rules/no-class-ternary.md
+++ b/docs/rules/no-class-ternary.md
@@ -1,0 +1,51 @@
+# Disallow class-selecting ternaries in className / tw() / always() (no-class-ternary)
+
+The Canopy classname helpers provide `toggle(cond, whenTrue, whenFalse)` for
+choosing between two class sets. Writing that choice as a raw ternary — whether
+in a JSX `className` attribute or inside `tw()` / `always()` — is harder to scan
+and inconsistent with the helper API.
+
+## Rule Details
+
+This rule reports a ternary whose **both** branches are non-empty class
+expressions when it appears in any of:
+
+- a JSX `className` / `class` attribute — `<div className={cond ? "a" : "b"} />`
+- a `tw()` or `always()` call — `tw(cond ? "a" : "b")`
+
+It descends through nested arrays, string concatenation, and template literals.
+A ternary with an empty branch (`cond ? "x" : ""`) is handled by
+[`no-conditional-class`](./no-conditional-class.md) instead.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+/*eslint canopy/no-class-ternary: "error"*/
+
+<div className={isDragOver ? "border-2" : "border"} />;
+<div className={tw(isDragOver ? "border-2" : "border")} />;
+<div className={always("base", open ? "max-h-[400px]" : "shrink-0")} />;
+<div className={tw(["base", cond ? "a" : "b"])} />;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+/*eslint canopy/no-class-ternary: "error"*/
+
+<div className={toggle(isDragOver, "border-2", "border")} />;
+<div className={tw(toggle(isDragOver, "border-2", "border"))} />; 
+<div className={always("base", toggle(open, "max-h-[400px]", "shrink-0"))} />;
+<div className={maybe(cond, "a")} />;
+```
+
+## Fixable
+
+This rule is auto-fixable (`eslint --fix`). The fix wraps the ternary in
+`toggle(...)` and **assumes `toggle` is already imported** — it does not add or
+modify imports.
+
+## When Not To Use It
+
+If a file doesn't use the Canopy classname helpers (`tw` / `always`), this rule
+won't apply to it. Disable the rule entirely if your project doesn't use them.

--- a/docs/rules/no-conditional-class.md
+++ b/docs/rules/no-conditional-class.md
@@ -1,0 +1,53 @@
+# Disallow conditional class expressions in className / tw() / always() (no-conditional-class)
+
+The Canopy classname helpers provide `maybe(cond, ...classes)` to conditionally
+include classes. Writing that as an empty-branch ternary (`cond ? "x" : ""`) or a
+`cond && "x"` short-circuit — whether in a JSX `className` attribute or inside
+`tw()` / `always()` — is less clear and inconsistent with the helper API.
+
+## Rule Details
+
+In a JSX `className` / `class` attribute, or inside a `tw()` / `always()` call,
+this rule reports:
+
+- a ternary with exactly one empty-string branch — `cond ? "x" : ""` or `cond ? "" : "y"`
+- a `cond && "x"` short-circuit whose right-hand side is a class literal
+
+It descends through nested arrays, string concatenation, and template literals.
+A ternary with two non-empty branches is handled by
+[`no-class-ternary`](./no-class-ternary.md) instead.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+/*eslint canopy/no-conditional-class: "error"*/
+
+<nav className={expanded ? "nav-expanded" : ""} />;
+<button className={isOpen && "visible"} />;
+<span className={tw("base", showActions ? "pb-9" : "")} />;
+<div className={tw("base", menuOpen && "bg-[var(--cp-color-menu-hover-bg)]")} />;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+/*eslint canopy/no-conditional-class: "error"*/
+
+<nav className={maybe(expanded, "nav-expanded")} />;
+<button className={maybe(isOpen, "visible")} />;
+<span className={tw("base", maybe(showActions, "pb-9")) />;
+<div className={tw("base", maybe(menuOpen, "bg-[var(--cp-color-menu-hover-bg)]")) />;
+```
+
+## Fixable
+
+This rule is auto-fixable (`eslint --fix`). The fix rewrites to `maybe(...)`,
+negating the condition when the empty branch is first (`cond ? "" : "y"` →
+`maybe(!cond, "y")`, collapsing `!(!x)` to `x`), and **assumes `maybe` is
+imported** (it does not add or modify imports).
+
+## When Not To Use It
+
+If a file uses neither JSX `className` attributes nor the Canopy classname
+helpers (`tw` / `always`), this rule won't apply to it. Disable the rule entirely
+if your project doesn't use them.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,6 +99,8 @@ export default [
 
       // Canopy
       'canopy/no-cp-class-in-tw': 'warn',
+      'canopy/no-class-ternary': 'warn',
+      'canopy/no-conditional-class': 'warn',
 
       // TypeScript
       '@typescript-eslint/no-unused-vars': 'warn',

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,4 +1,6 @@
 import noCpClassInTw from './rules/no-cp-class-in-tw.js';
+import noClassTernary from './rules/no-class-ternary.js';
+import noConditionalClass from './rules/no-conditional-class.js';
 
 const plugin = {
   meta: {
@@ -6,6 +8,8 @@ const plugin = {
   },
   rules: {
     'no-cp-class-in-tw': noCpClassInTw,
+    'no-class-ternary': noClassTernary,
+    'no-conditional-class': noConditionalClass,
   },
 };
 

--- a/plugin/rules/no-class-ternary.js
+++ b/plugin/rules/no-class-ternary.js
@@ -1,0 +1,84 @@
+import { isClassnameContainerCall, isClassNameAttribute } from '../utils/classname-evaluation.js';
+
+const isEmptyString = (n) => n.type === 'Literal' && n.value === '';
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow a class-selecting ternary in a className attribute or tw()/always() call — use toggle(cond, whenTrue, whenFalse) instead.',
+      url: 'https://github.com/CanopyTax/eslint-config-canopy/blob/master/docs/rules/no-class-ternary.md',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useToggle: 'Use `toggle(cond, whenTrue, whenFalse)` instead of a classname ternary.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function report(node) {
+      context.report({
+        node,
+        messageId: 'useToggle',
+        fix(fixer) {
+          const test = sourceCode.getText(node.test);
+          const consequent = sourceCode.getText(node.consequent);
+          const alternate = sourceCode.getText(node.alternate);
+          return fixer.replaceText(node, `toggle(${test}, ${consequent}, ${alternate})`);
+        },
+      });
+    }
+
+    function walk(node) {
+      if (!node) return;
+
+      switch (node.type) {
+        case 'ConditionalExpression':
+          if (!isEmptyString(node.consequent) && !isEmptyString(node.alternate)) {
+            report(node);
+          }
+          return;
+        case 'TemplateLiteral':
+          node.expressions.forEach(walk);
+          return;
+        case 'CallExpression':
+          if (isClassnameContainerCall(node)) return;
+          node.arguments.forEach(walk);
+          return;
+        case 'LogicalExpression':
+          walk(node.left);
+          walk(node.right);
+          return;
+        case 'ArrayExpression':
+          node.elements.forEach(walk);
+          return;
+        case 'BinaryExpression':
+          if (node.operator === '+') {
+            walk(node.left);
+            walk(node.right);
+          }
+          return;
+        default:
+          return;
+      }
+    }
+
+    return {
+      // tw()/always() calls anywhere.
+      CallExpression(node) {
+        if (!isClassnameContainerCall(node)) return;
+        node.arguments.forEach(walk);
+      },
+      // Anything inside an element's className/class attribute.
+      JSXAttribute(node) {
+        if (!isClassNameAttribute(node)) return;
+        if (node.value?.type !== 'JSXExpressionContainer') return;
+        walk(node.value.expression);
+      },
+    };
+  },
+};

--- a/plugin/rules/no-conditional-class.js
+++ b/plugin/rules/no-conditional-class.js
@@ -1,0 +1,115 @@
+import { isClassnameContainerCall, isClassNameAttribute } from '../utils/classname-evaluation.js';
+
+const isEmptyString = (n) => n.type === 'Literal' && n.value === '';
+const isClassLiteral = (n) =>
+  (n.type === 'Literal' && typeof n.value === 'string') || n.type === 'TemplateLiteral';
+
+// Negating a non-trivial test needs parentheses to preserve precedence.
+const needsParens = (n) =>
+  !['Identifier', 'MemberExpression', 'CallExpression', 'OptionalMemberExpression', 'OptionalCallExpression'].includes(
+    n.type,
+  );
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow an empty-branch ternary (`cond ? "x" : ""`) or `cond && "x"` class expression in a className attribute or tw()/always() call — use maybe(cond, "x") instead.',
+      url: 'https://github.com/CanopyTax/eslint-config-canopy/blob/master/docs/rules/no-conditional-class.md',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useMaybe: 'Use `maybe(cond, classes)` for conditional classes instead of `cond ? "x" : ""` or `cond && "x"`.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function negate(testNode) {
+      if (testNode.type === 'UnaryExpression' && testNode.operator === '!') {
+        return sourceCode.getText(testNode.argument);
+      }
+      const sourceText = sourceCode.getText(testNode);
+      return needsParens(testNode) ? `!(${sourceText})` : `!${sourceText}`;
+    }
+
+    function report(node, altEmpty) {
+      context.report({
+        node,
+        messageId: 'useMaybe',
+        fix(fixer) {
+          const conditional = altEmpty ? sourceCode.getText(node.test) : negate(node.test);
+          const className = sourceCode.getText(altEmpty ? node.consequent : node.alternate);
+          return fixer.replaceText(node, `maybe(${conditional}, ${className})`);
+        },
+      });
+    }
+
+    function reportLogical(node) {
+      context.report({
+        node,
+        messageId: 'useMaybe',
+        fix(fixer) {
+          const conditional = sourceCode.getText(node.left);
+          const className = sourceCode.getText(node.right);
+          return fixer.replaceText(node, `maybe(${conditional}, ${className})`);
+        },
+      });
+    }
+
+    function walk(node) {
+      if (!node) return;
+
+      switch (node.type) {
+        case 'ConditionalExpression': {
+          const consEmpty = isEmptyString(node.consequent);
+          const altEmpty = isEmptyString(node.alternate);
+
+          if (consEmpty !== altEmpty) report(node, altEmpty);
+          return;
+        }
+        case 'LogicalExpression':
+          if (node.operator === '&&' && isClassLiteral(node.right)) {
+            reportLogical(node);
+            return;
+          }
+          walk(node.left);
+          walk(node.right);
+          return;
+        case 'TemplateLiteral':
+          node.expressions.forEach(walk);
+          return;
+        case 'CallExpression':
+          if (isClassnameContainerCall(node)) return;
+          node.arguments.forEach(walk);
+          return;
+        case 'ArrayExpression':
+          node.elements.forEach(walk);
+          return;
+        case 'BinaryExpression':
+          if (node.operator === '+') {
+            walk(node.left);
+            walk(node.right);
+          }
+          return;
+        default:
+          return;
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (!isClassnameContainerCall(node)) return;
+        node.arguments.forEach(walk);
+      },
+      JSXAttribute(node) {
+        if (!isClassNameAttribute(node)) return;
+        if (node.value?.type !== 'JSXExpressionContainer') return;
+        walk(node.value.expression);
+      },
+    };
+  },
+};

--- a/plugin/rules/no-cp-class-in-tw.js
+++ b/plugin/rules/no-cp-class-in-tw.js
@@ -1,7 +1,10 @@
+import { isClassnameContainerCall } from '../utils/classname-evaluation.js';
+
 // Match cp-* at string start or after any non-word-non-hyphen character.
 // Excluding `-` preserves CSS custom properties like `--cp-color-*` inside
 // arbitrary-value brackets (e.g. `bg-[var(--cp-color-app-border)]`).
 const CP_TOKEN_RE = /(?:^|[^\w-])(cp-[A-Za-z0-9_-]+)/g;
+const TW_CONTAINER_NAMES = new Set(['tw']);
 
 function findCpTokens(str) {
   if (typeof str !== 'string') return [];
@@ -110,7 +113,7 @@ export default {
 
     return {
       CallExpression(node) {
-        if (node.callee.type !== 'Identifier' || node.callee.name !== 'tw') return;
+        if (!isClassnameContainerCall(node, TW_CONTAINER_NAMES)) return;
         const suggest = buildAlwaysSuggestion(node);
         node.arguments.forEach((arg) => walkInsideTw(arg, suggest));
       },

--- a/plugin/utils/classname-evaluation.js
+++ b/plugin/utils/classname-evaluation.js
@@ -1,0 +1,9 @@
+export const CLASSNAME_CONTAINER_SET = new Set(['tw', 'always']);
+
+export function isClassnameContainerCall(node, containerNames = CLASSNAME_CONTAINER_SET) {
+  return node?.type === 'CallExpression' && node.callee.type === 'Identifier' && containerNames.has(node.callee.name);
+}
+
+export const CLASSNAME_ATTRIBUTE_SET = new Set(['className', 'class']);
+export const isClassNameAttribute = (node) =>
+  node.name?.type === 'JSXIdentifier' && CLASSNAME_ATTRIBUTE_SET.has(node.name.name);

--- a/test/rules/no-class-ternary.test.js
+++ b/test/rules/no-class-ternary.test.js
@@ -1,0 +1,65 @@
+import { RuleTester } from 'eslint';
+import rule from '../../plugin/rules/no-class-ternary.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-class-ternary', rule, {
+  valid: [
+    // Already using toggle
+    { code: `toggle(cond, "a", "b")` },
+    { code: `tw(toggle(cond, "a", "b"))` },
+    // Empty branch is caught in no-conditional-class rule
+    { code: `tw(cond ? "a" : "")` },
+    { code: `tw(cond ? "" : "b")` },
+    { code: `tw("flex", maybe(x, "a"))` },
+    // Ternary outside classname helpers
+    { code: `const c = cond ? "a" : "b"` },
+    { code: `foo(cond ? "a" : "b")` },
+    // className attribute (JSX)
+    { code: `const el = <div className={toggle(cond, "a", "b")} />` },
+    { code: `const el = <div className="static" />` },
+    { code: `const el = <div className={dynamicClass} />` },
+  ],
+  invalid: [
+    {
+      code: `tw(isDragOver ? "border-2" : "border")`,
+      output: `tw(toggle(isDragOver, "border-2", "border"))`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+    {
+      code: `tw("base", open ? "max-h-[400px]" : "shrink-0")`,
+      output: `tw("base", toggle(open, "max-h-[400px]", "shrink-0"))`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+    {
+      code: `always(cond ? "a" : "b")`,
+      output: `always(toggle(cond, "a", "b"))`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+    {
+      code: `tw(["base", cond ? "a" : "b"])`,
+      output: `tw(["base", toggle(cond, "a", "b")])`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+    {
+      // bare className attribute ternary (no helper wrapper)
+      code: `const el = <div className={cond ? "a" : "b"} />`,
+      output: `const el = <div className={toggle(cond, "a", "b")} />`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+    {
+      // ternary inside tw() inside className -> reported once (no double)
+      code: `const el = <div className={tw(cond ? "a" : "b")} />`,
+      output: `const el = <div className={tw(toggle(cond, "a", "b"))} />`,
+      errors: [{ messageId: 'useToggle' }],
+    },
+  ],
+});

--- a/test/rules/no-conditional-class.test.js
+++ b/test/rules/no-conditional-class.test.js
@@ -1,0 +1,74 @@
+import { RuleTester } from 'eslint';
+import rule from '../../plugin/rules/no-conditional-class.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-conditional-class', rule, {
+  valid: [
+    { code: `maybe(cond, "truncate")` },
+    { code: `tw(maybe(cond, "truncate"))` },
+    // Non-empty branches is covered by no-class-ternary
+    { code: `tw(cond ? "a" : "b")` },
+    { code: `tw("base", cond && classVar)` },
+    { code: `tw(cond || "fallback")` },
+    // Outside classname helpers
+    { code: `const c = cond ? "x" : ""` },
+    { code: `foo(cond && "x")` },
+    // className attribute (JSX)
+    { code: `const el = <div className={maybe(cond, "x")} />` },
+    { code: `const el = <div className={cond ? "a" : "b"} />` },
+    { code: `const el = <div className="static" />` },
+  ],
+  invalid: [
+    {
+      code: `tw("base", showActions ? "pb-9" : "")`,
+      output: `tw("base", maybe(showActions, "pb-9"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      code: `tw(cond ? "" : "y")`,
+      output: `tw(maybe(!cond, "y"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      code: `tw(!active ? "" : "y")`,
+      output: `tw(maybe(active, "y"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      code: `tw(a && b ? "" : "y")`,
+      output: `tw(maybe(!(a && b), "y"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      code: `tw("base", menuOpen && "bg-x")`,
+      output: `tw("base", maybe(menuOpen, "bg-x"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      code: `always(open && "opacity-60")`,
+      output: `always(maybe(open, "opacity-60"))`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      // bare className && short-circuit (no helper wrapper)
+      code: `const el = <div className={isOpen && "visible"} />`,
+      output: `const el = <div className={maybe(isOpen, "visible")} />`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+    {
+      // bare className empty-branch ternary
+      code: `const el = <div className={expanded ? "nav-expanded" : ""} />`,
+      output: `const el = <div className={maybe(expanded, "nav-expanded")} />`,
+      errors: [{ messageId: 'useMaybe' }],
+    },
+  ],
+});


### PR DESCRIPTION
# Summary

Extends the eslint-config-canopy plugin with two auto-fixable rules that enforce Canopy's classname helper API (toggle/maybe) over raw ternaries and short-circuits. Also backfills the missing opt-in suggestion fix and per-rule docs across all classname linting rules.

## New rules

All rules share a similar pattern of a recursive AST walker where it descends through arrays, template literals, string concatenation, and nested calls, narrowing down its scope to tw()/always() call sites and bare JSX className/class attributes.

`canopy/no-class-ternary` flags both-non-empty ternaries in className attrs and tw()/always() calls; auto-fixes to `toggle(cond, a, b)`
`canopy/no-conditional-class` flags empty-branch ternaries and cond && "x" short-circuits in the same locations; auto-fixes to `maybe(cond, x)` with negation collapsing, i.e. `(!(!x) → x)`

## Test

Running `yarn eslint` in `coworker-ui` triggers the warnings

<img width="924" height="506" alt="image" src="https://github.com/user-attachments/assets/f13f95af-82a0-41cf-8923-d66545d447d4" />

<img width="1163" height="633" alt="image" src="https://github.com/user-attachments/assets/6be82dc8-d1d7-4ba1-9a86-6bc9a85974e0" />

<img width="1173" height="578" alt="image" src="https://github.com/user-attachments/assets/1028259a-42aa-4d91-a13a-6df6aa2dbbef" />

Running `yarn eslint --fix` to resolve the  warning. 

**NOTE: The fix assumes that the `tw` helpers will be in scope, and that suggestion rewrites into `always/maybe/toggle(...)` would not touch imports**

https://github.com/user-attachments/assets/7945376d-7559-4957-ab05-a80578e39d4f