### PR TITLE
Explore/no hardcoded color

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ export default [
 | Rule | Description |
 | --- | --- |
 | [`canopy/no-cp-class-in-tw`](docs/rules/no-cp-class-in-tw.md) | Disallows Canopy `cp-*` class tokens inside `tw(...)` calls. Tailwind's `tw()` helper applies a per-app prefix to every token, so `tw("cp-body")` produces a broken class like `fo-cp-body`. Use `always("cp-body", tw(...))` or place the `cp-*` class outside `tw()`. Offers a suggestion fix for flat string-literal calls. |
+| [`canopy/no-hardcoded-color`](docs/rules/no-hardcoded-color.md) | Disallows hardcoded hex colors in JSX `style` prop values (`'#000'`) and Tailwind arbitrary-value class strings (`text-[#000]`). Use Canopy design tokens (`var(--cp-color-*)`) instead. See the [color palette](https://storybook.canopytax.com/?path=/docs/design-color-palette--docs). |

--- a/docs/rules/no-hardcoded-color.md
+++ b/docs/rules/no-hardcoded-color.md
@@ -1,0 +1,82 @@
+# Disallow hardcoded colors in style props and className arbitrary values (no-hardcoded-color)
+
+Hardcoded colors bypass the Canopy design token system. When a hex, rgb, or hsl value is embedded
+in a `style` prop or a Tailwind arbitrary-value class, the color becomes invisible to the design
+system, making theme changes and brand enforcement impossible.
+
+Use `var(--cp-color-*)` CSS custom properties so all colors are sourced from the Canopy token
+palette. Any CSS variable reference that does not start with `--cp-color-` is also flagged.
+
+> **Finding the right token:** browse the full Canopy color palette at
+> <https://storybook.canopytax.com/?path=/docs/design-color-palette--docs>
+
+## Rule Details
+
+In a JSX `style` attribute or a `className` / `class` attribute, this rule reports:
+
+**In `style` prop object values:**
+- hex color literals — `'#000'`, `'#ff0000'`, `'#ff000080'`
+- `rgb()` / `rgba()` / `hsl()` / `hsla()` function literals
+- `var(--X)` references where `X` does not start with `cp-`
+
+**In class strings** (inside `tw()` / `always()` calls, JSX `className` / `class` attributes,
+or nested expressions within them) — specifically within Tailwind arbitrary-value brackets `[...]`:
+- hex: `text-[#000]`
+- color functions: `bg-[rgb(0,0,0)]`, `border-[hsl(0,0%,0%)]`
+- non-approved CSS variables: `text-[var(--some-var)]` (flagged), `text-[var(--cp-color-app-text)]` (allowed)
+- CSS property shorthand arbitrary syntax: `[color:#000]`, `[background-color:rgb(0,0,0)]`
+
+The rule descends through `tw()` / `always()` calls, ternaries, `&&` short-circuits, arrays,
+template literals, and string concatenation.
+
+## Options
+
+```json
+{ "canopy/no-hardcoded-color": ["warn", { "checkTailwindColors": false }] }
+```
+
+### `checkTailwindColors` (default: `false`)
+
+When `true`, also flags Tailwind built-in named color utilities such as `bg-red-500`,
+`text-white`, `border-gray-100`. This option exists as an optional toggle so the check can be
+enabled when adopting a new color token system without changing the rule's detection logic 
+for hardcoded values.
+
+## Examples of incorrect code
+
+```jsx
+/*eslint canopy/no-hardcoded-color: "error"*/
+
+<div style={{ color: '#000' }} />;
+<div style={{ color: 'rgb(0, 0, 0)' }} />;
+<div style={{ color: 'rgba(0, 0, 0, 0.85)' }} />;
+<div style={{ color: 'hsl(0, 0%, 0%)' }} />;
+<div style={{ color: 'var(--some-other-var)' }} />;
+<div className={tw("text-[#000]")} />;
+<div className={tw("bg-[rgb(0,0,0)]")} />;
+<div className={tw("border-[var(--other-color)]")} />;
+<div className="text-[#abc]" />;
+```
+
+With `{ "checkTailwindColors": true }`:
+
+```jsx
+<div className={tw("bg-red-500")} />;
+<div className="text-white border-gray-100" />;
+```
+
+## Examples of correct code
+
+```jsx
+/*eslint canopy/no-hardcoded-color: "error"*/
+
+<div style={{ color: 'var(--cp-color-app-text)' }} />;
+<div style={{ background: 'var(--cp-color-app-bg)' }} />;
+<div className={tw("bg-[var(--cp-color-app-border)]")} />;
+<div className={tw("text-sm font-semibold")} />;
+```
+
+## When Not To Use It
+
+Disable this rule only if your project has a documented reason to use hardcoded colors
+(e.g., a one-off export or generated artifact that cannot reference CSS custom properties).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,6 +99,7 @@ export default [
 
       // Canopy
       'canopy/no-cp-class-in-tw': 'warn',
+      'canopy/no-hardcoded-color': 'warn',
 
       // TypeScript
       '@typescript-eslint/no-unused-vars': 'warn',

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,4 +1,5 @@
 import noCpClassInTw from './rules/no-cp-class-in-tw.js';
+import noHardcodedColor from './rules/no-hardcoded-color.js';
 
 const plugin = {
   meta: {
@@ -6,6 +7,7 @@ const plugin = {
   },
   rules: {
     'no-cp-class-in-tw': noCpClassInTw,
+    'no-hardcoded-color': noHardcodedColor,
   },
 };
 

--- a/plugin/rules/no-hardcoded-color.js
+++ b/plugin/rules/no-hardcoded-color.js
@@ -1,0 +1,190 @@
+// Matches valid CSS hex colors: #rgb, #rgba, #rrggbb, #rrggbbaa
+// (only 3/4/6/8 digits are valid — 5 and 7 are not)
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+// Matches rgb/rgba/hsl/hsla color functions at string start
+const COLOR_FN_RE = /^(rgba?|hsla?)\s*\(/i;
+// Approved CSS custom property prefix — only --cp-* passes
+const CP_COLOR_VAR_RE = /^var\(--cp-/;
+// Detects any var() reference so we can test it against the allowlist
+const ANY_VAR_RE = /^var\(--/;
+
+const CONTAINER_FNS = new Set(['tw', 'always']);
+const CLASSNAME_ATTRS = new Set(['className', 'class']);
+
+/**
+ * Tailwind named color detection
+ * Enabled via { checkTailwindColors: true } rule option (default: false).
+ * Isolated here because there is a WIP token system and we only want to replace this block.
+ */
+const TW_COLOR_NAMES = [
+  'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber',
+  'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky', 'blue',
+  'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
+];
+const TW_UTILITY_PREFIXES = [
+  'bg', 'text', 'border', 'ring', 'outline', 'shadow', 'divide',
+  'fill', 'stroke', 'accent', 'caret', 'decoration', 'from', 'via', 'to',
+];
+
+const TW_COLOR_TOKEN_RE = new RegExp(
+  `^(?:${TW_UTILITY_PREFIXES.join('|')})-` +
+  `(?:white|black|transparent|(?:${TW_COLOR_NAMES.join('|')})-(?:50|[1-9]00|950))$`,
+);
+
+function findTailwindColorTokens(str) {
+  if (typeof str !== 'string') return [];
+  return str.split(/\s+/).filter((token) => {
+    // Strip variant prefixes: hover:bg-red-500 → bg-red-500
+    const base = token.includes(':') ? token.slice(token.lastIndexOf(':') + 1) : token;
+    return TW_COLOR_TOKEN_RE.test(base);
+  });
+}
+
+function staticString(node) {
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (node.type === 'TemplateLiteral' && node.quasis.length === 1) {
+    return node.quasis[0].value.cooked ?? node.quasis[0].value.raw ?? null;
+  }
+  return null;
+}
+
+// Returns the flagged value string if a style-prop literal value is a
+// hardcoded or non-approved color; null otherwise.
+function checkStyleValue(value) {
+  if (typeof value !== 'string') return null;
+  if (HEX_COLOR_RE.test(value)) return value;
+  if (COLOR_FN_RE.test(value)) return value;
+  if (ANY_VAR_RE.test(value) && !CP_COLOR_VAR_RE.test(value)) return value;
+  return null;
+}
+
+function findHardcodedInArbitraryValues(str) {
+  if (typeof str !== 'string') return [];
+  const found = [];
+  for (const m of str.matchAll(/\[([^\]]{1,256})\]/g)) {
+    let content = m[1];
+    // Strip CSS property shorthand prefix: [color:rgb(...)] → rgb(...)
+    const colonIdx = content.indexOf(':');
+    if (colonIdx > 0 && /^[a-zA-Z-]+$/.test(content.slice(0, colonIdx))) {
+      content = content.slice(colonIdx + 1).trim();
+    }
+    if (HEX_COLOR_RE.test(content)) {
+      found.push(content);
+    } else if (COLOR_FN_RE.test(content)) {
+      found.push(content);
+    } else if (ANY_VAR_RE.test(content) && !CP_COLOR_VAR_RE.test(content)) {
+      found.push(content);
+    }
+  }
+  return found;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow hardcoded colors and non-Canopy CSS variables in style props and className arbitrary values.',
+      url: 'https://github.com/CanopyTax/eslint-config-canopy/blob/master/docs/rules/no-hardcoded-color.md',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          // When true, also flags Tailwind built-in named color utilities
+          // (e.g. bg-red-500, text-white). Off by default — enable once a
+          // full token migration is underway or when switching color systems.
+          checkTailwindColors: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noHardcodedColor:
+        '"{{value}}" is not an approved color — use a Canopy design token (--cp-color-*). Find a matching token at https://storybook.canopytax.com/?path=/docs/design-color-palette--docs',
+    },
+  },
+
+  create(context) {
+    const { checkTailwindColors = false } = context.options[0] ?? {};
+
+    function report(node, value) {
+      context.report({ node, messageId: 'noHardcodedColor', data: { value } });
+    }
+
+    function checkClassLiteral(node, str) {
+      for (const v of findHardcodedInArbitraryValues(str)) report(node, v);
+      if (checkTailwindColors) {
+        for (const token of findTailwindColorTokens(str)) report(node, token);
+      }
+    }
+
+    function walk(node) {
+      if (!node) return;
+      switch (node.type) {
+        case 'Literal':
+          if (typeof node.value === 'string') checkClassLiteral(node, node.value);
+          return;
+        case 'TemplateLiteral':
+          for (const q of node.quasis) checkClassLiteral(q, q.value.cooked ?? q.value.raw ?? '');
+          return;
+        case 'CallExpression':
+          if (node.callee.type === 'Identifier' && CONTAINER_FNS.has(node.callee.name)) return;
+          for (const arg of node.arguments) walk(arg);
+          return;
+        case 'ConditionalExpression':
+          walk(node.consequent);
+          walk(node.alternate);
+          return;
+        case 'LogicalExpression':
+          walk(node.left);
+          walk(node.right);
+          return;
+        case 'ArrayExpression':
+          for (const el of node.elements) if (el) walk(el);
+          return;
+        case 'BinaryExpression':
+          if (node.operator === '+') {
+            walk(node.left);
+            walk(node.right);
+          }
+          return;
+        default:
+          return;
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || !CONTAINER_FNS.has(node.callee.name)) return;
+        for (const arg of node.arguments) walk(arg);
+      },
+
+      JSXAttribute(node) {
+        if (node.name?.type !== 'JSXIdentifier') return;
+        const attrName = node.name.name;
+
+        if (CLASSNAME_ATTRS.has(attrName)) {
+          if (!node.value) return;
+          if (node.value.type === 'Literal' && typeof node.value.value === 'string') {
+            checkClassLiteral(node.value, node.value.value);
+          } else if (node.value.type === 'JSXExpressionContainer') {
+            walk(node.value.expression);
+          }
+        } else if (attrName === 'style') {
+          if (node.value?.type !== 'JSXExpressionContainer') return;
+          const expr = node.value.expression;
+          if (expr.type !== 'ObjectExpression') return;
+          for (const prop of expr.properties) {
+            if (prop.type !== 'Property') continue;
+            const val = prop.value;
+            const str = staticString(val);
+            if (str === null) continue;
+            const flagged = checkStyleValue(str);
+            if (flagged) report(val, flagged);
+          }
+        }
+      },
+    };
+  },
+};

--- a/test/rules/no-hardcoded-color.test.js
+++ b/test/rules/no-hardcoded-color.test.js
@@ -1,0 +1,186 @@
+import { RuleTester } from 'eslint';
+import rule from '../../plugin/rules/no-hardcoded-color.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-hardcoded-color', rule, {
+  valid: [
+    { code: `const el = <div style={{ color: 'var(--cp-color-app-text)' }} />` },
+    { code: `const el = <div style={{ background: 'var(--cp-color-app-bg)' }} />` },
+    { code: `const el = <div style={{ color: colorVar }} />` },
+    { code: `const el = <div style={{ padding: '8px' }} />` },
+    { code: 'const el = <div style={{ color: `var(--cp-color-app-text)` }} />' },
+    { code: 'const el = <div style={{ color: `${colorVar}` }} />' },
+    { code: `const el = <div style={{ color: '#12345' }} />` },
+    { code: `tw("bg-[var(--cp-color-app-border)]")` },
+    { code: `const el = <div className={tw("text-[var(--cp-color-app-text)]")} />` },
+    { code: `tw("flex p-4 rounded-md")` },
+    { code: `const el = <div className={tw("text-sm font-semibold")} />` },
+    { code: `const el = <div className="text-sm p-4" />` },
+    { code: `tw("bg-red-500 text-white")` },
+    { code: `const el = <div className="bg-blue-300 border-gray-100" />` },
+    { code: `const id = '#000'` },
+    { code: `const color = 'rgb(0, 0, 0)'` },
+  ],
+
+  invalid: [
+    {
+      code: `const el = <div style={{ color: '#000' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `const el = <div style={{ color: '#ff0000' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#ff0000' } }],
+    },
+    {
+      code: `const el = <div style={{ color: '#ff000080' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#ff000080' } }],
+    },
+    {
+      code: `const el = <div style={{ color: '#000', background: '#fff' }} />`,
+      errors: [
+        { messageId: 'noHardcodedColor', data: { value: '#000' } },
+        { messageId: 'noHardcodedColor', data: { value: '#fff' } },
+      ],
+    },
+    {
+      code: `const el = <div style={{ color: 'rgb(0, 0, 0)' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'rgb(0, 0, 0)' } }],
+    },
+    {
+      code: `const el = <div style={{ color: 'rgba(0, 0, 0, 0.5)' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'rgba(0, 0, 0, 0.5)' } }],
+    },
+    {
+      code: `const el = <div style={{ color: 'hsl(0, 0%, 0%)' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'hsl(0, 0%, 0%)' } }],
+    },
+    {
+      code: `const el = <div style={{ color: 'hsla(0, 0%, 0%, 1)' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'hsla(0, 0%, 0%, 1)' } }],
+    },
+    {
+      code: `const el = <div style={{ color: 'var(--some-other-var)' }} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'var(--some-other-var)' } }],
+    },
+    {
+      code: 'const el = <div style={{ color: `#000` }} />',
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: 'const el = <div style={{ color: `rgb(0, 0, 0)` }} />',
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'rgb(0, 0, 0)' } }],
+    },
+    {
+      code: 'const el = <div style={{ color: `var(--some-other-var)` }} />',
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'var(--some-other-var)' } }],
+    },
+    {
+      code: `tw("text-[#000]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `tw("flex text-[#ff0000] p-4")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#ff0000' } }],
+    },
+    {
+      code: `tw("text-[#000] bg-[#fff]")`,
+      errors: [
+        { messageId: 'noHardcodedColor', data: { value: '#000' } },
+        { messageId: 'noHardcodedColor', data: { value: '#fff' } },
+      ],
+    },
+    {
+      code: `tw("[color:#000]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `tw("text-[rgb(0,0,0)]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'rgb(0,0,0)' } }],
+    },
+    {
+      code: `tw("bg-[rgba(255,0,0,0.5)]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'rgba(255,0,0,0.5)' } }],
+    },
+    {
+      code: `tw("text-[hsl(0,0%,0%)]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'hsl(0,0%,0%)' } }],
+    },
+    {
+      code: `tw("[color:hsl(200,50%,50%)]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'hsl(200,50%,50%)' } }],
+    },
+    {
+      code: `tw("text-[var(--some-var)]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'var(--some-var)' } }],
+    },
+    {
+      code: `const el = <div className="bg-[var(--other-color)]" />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'var(--other-color)' } }],
+    },
+    {
+      code: `always("text-[#abc123]")`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#abc123' } }],
+    },
+    {
+      code: `const el = <div className={tw("text-[#000]")} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `const el = <div className={tw("bg-[#ff0000]")} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#ff0000' } }],
+    },
+    {
+      code: `const el = <div className="text-[#abc]" />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#abc' } }],
+    },
+    {
+      code: `const el = <div className={isActive && "text-[#000]"} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `const el = <div className={cond ? "text-[#000]" : "text-blue-500"} />`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `tw(toggle(cond, "text-[#000]", "text-white"))`,
+      errors: [{ messageId: 'noHardcodedColor', data: { value: '#000' } }],
+    },
+    {
+      code: `tw("bg-red-500")`,
+      options: [{ checkTailwindColors: true }],
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'bg-red-500' } }],
+    },
+    {
+      code: `tw("flex bg-blue-300 p-4")`,
+      options: [{ checkTailwindColors: true }],
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'bg-blue-300' } }],
+    },
+    {
+      code: `tw("text-white border-gray-100")`,
+      options: [{ checkTailwindColors: true }],
+      errors: [
+        { messageId: 'noHardcodedColor', data: { value: 'text-white' } },
+        { messageId: 'noHardcodedColor', data: { value: 'border-gray-100' } },
+      ],
+    },
+    {
+      code: `tw("hover:bg-red-500")`,
+      options: [{ checkTailwindColors: true }],
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'hover:bg-red-500' } }],
+    },
+    {
+      code: `const el = <div className="bg-slate-200 text-sm" />`,
+      options: [{ checkTailwindColors: true }],
+      errors: [{ messageId: 'noHardcodedColor', data: { value: 'bg-slate-200' } }],
+    },
+  ],
+});


### PR DESCRIPTION
# Summary

Extends the eslint-config-canopy plugin with a rules that encourages the use of Canopy's global color variables over raw hex/rgb/hsl values. Added an optional arg for setting off warnings for use of tailwind color variables.

## Flagged patterns
Patterns caught by this rule include the following:
```
style={{ color: 'rgb(0,0,0)' }} / hsl(...) / hsla(...)
style={{ color: 'var(--some-var)' }}
tw("bg-[rgb(0,0,0)]") / [hsl(...)]
tw("text-[var(--other)]") → flagged; [var(--cp-color-app-text)]
[color:#000] CSS property shorthand in arbitrary values
```

## Test
Warnings in `coworker-ui` detected:
<img width="1261" height="696" alt="image" src="https://github.com/user-attachments/assets/ad593c77-0eb4-434b-87f3-267579111380" />
